### PR TITLE
Add option of newline at EOF.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ gulp.task('tsconfig_files', function () {
 
 ``` js
 {
-  absolute: true,            // default: false
-  path:     'tsconfig.json', // default: 'tsconfig.json'
-  indent:   2,               // default: 2
+  absolute:    true,            // default: false
+  path:        'tsconfig.json', // default: 'tsconfig.json'
+  indent:      2,               // default: 2
+  newline_eof: true,            // default: false
 }
 ```

--- a/index.js
+++ b/index.js
@@ -21,6 +21,10 @@ module.exports = function(options) {
     options.absolute = false;
   }
 
+  if (typeof options.newline_eof === 'undefined') {
+    options.newline_eof = false;
+  }
+
   var readConfig = function (callback) {
     fs.readFile(options.path, function (err, data) {
       if (err) {
@@ -41,6 +45,9 @@ module.exports = function(options) {
     } catch (err) {
       callback(err);
       return;
+    }
+    if (options.newline_eof) {
+      data += "\n";
     }
     fs.writeFile(options.path, data, callback);
   };


### PR DESCRIPTION
POSIX says 'A sequence of zero or more non- <newline> characters plus a terminating <newline> character.'(http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206).
http://stackoverflow.com/questions/729692/why-should-files-end-with-a-newline

For example.
When Vim edits a file without newline at EOF, Vim adds newline at EOF automatically.
Then a following diff arises.

``` diff
diff --git a/frontend/tsconfig.json b/frontend/tsconfig.json
index 885c070..aac762c 100644
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -22,4 +22,4 @@
     "src/models/resource.ts",
     "src/models/s3_bucket.ts"
   ]
-}
+}
\ No newline at end of file
```

This patch solves the above problem.
When `newline_eof` option is true, this software adds newlien at EOF.
