### PR TITLE
Add 'relative' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,6 @@ gulp.task('tsconfig_files', function () {
   path:        'tsconfig.json', // default: 'tsconfig.json'
   indent:      2,               // default: 2
   newline_eof: true,            // default: false
+  relative:    'some/folder/',  // default: '.'
 }
 ```

--- a/index.js
+++ b/index.js
@@ -25,6 +25,10 @@ module.exports = function(options) {
     options.newline_eof = false;
   }
 
+  if (typeof options.relative === 'undefined') {
+    options.relative = '.';
+  }
+
   var readConfig = function (callback) {
     fs.readFile(options.path, function (err, data) {
       if (err) {
@@ -59,7 +63,7 @@ module.exports = function(options) {
     if (options.absolute) {
       filePath = path.resolve(filePath);
     } else {
-      filePath = path.relative('.', filePath);
+      filePath = path.relative(options.relative, filePath);
     }
     files.push(filePath);
     this.emit('data', file);


### PR DESCRIPTION
Added a 'relative' option so that files can be relative to a path other than local file. Useful in combination with 'path' option.
