### PR TITLE
Add template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ gulp.task('tsconfig_files', function () {
 {
   absolute:     true,            // default: false
   path:         'tsconfig.json', // default: 'tsconfig.json'
+  template:     'blanktsconf.json' // default same as path
   indent:       2,               // default: 2
   newline_eof:  true,            // default: false
   relative_dir: 'some/folder/'   // default: '.'

--- a/index.js
+++ b/index.js
@@ -13,6 +13,10 @@ module.exports = function (options) {
     options.path = 'tsconfig.json';
   }
 
+  if (typeof options.template === 'undefined') {
+    options.template = options.path;
+  }
+
   if (typeof options.indent === 'undefined') {
     options.indent = 2;
   }
@@ -30,7 +34,7 @@ module.exports = function (options) {
   }
 
   var readConfig = function (callback) {
-    fs.readFile(options.path, function (err, data) {
+    fs.readFile(options.template, function (err, data) {
       if (err) {
         callback(err, null)
       } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-tsconfig-files",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Update tsconfig files array with glob",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-tsconfig-files",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Update tsconfig files array with glob",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This might be a useful feature. The reasoning behind it is that I keep overwriting my own tsconfig files (and don't want to .gitignore them because they are important). So one solution is to keep tsconfig templates in a separate place, and create tsconfig files at build time (and possibly discard them afterwards).

Is this useful?
